### PR TITLE
Egress Only Internet Gatway

### DIFF
--- a/eks/inputs.tf
+++ b/eks/inputs.tf
@@ -24,6 +24,18 @@ variable cidr_block {
   default = "10.2.0.0/16"
 }
 
+variable "enable_ipv6" {
+  default = false
+}
+
+variable "enable_nat" {
+  default = true
+}
+
+variable "enable_egress_only_internet_gateway" {
+  default = false
+}
+
 variable "zones" {
   default = ["us-west-2a", "us-west-2b"]
 }

--- a/eks/private_subnet.tf
+++ b/eks/private_subnet.tf
@@ -20,14 +20,14 @@ resource "aws_eip" "eips" {
 
 
 resource "aws_nat_gateway" "gw" {
-  count = var.nat_enabled ? 2 : 0
+  count = var.enable_nat ? 2 : 0
 
   allocation_id = length(var.eips) == 0 ? aws_eip.eips[count.index].id : var.eips[count.index].id
   subnet_id     = aws_subnet.public[count.index].id
 }
 
 resource "aws_route_table" "private" {
-  count = var.nat_enabled ? 2 : 0
+  count = var.enable_nat ? 2 : 0
   vpc_id = aws_vpc.vpc.id
 
   route {

--- a/eks/private_subnet.tf
+++ b/eks/private_subnet.tf
@@ -48,11 +48,11 @@ resource "aws_route" "ipv6" {
 
   route_table_id              = aws_route_table.private[count.index].id
   destination_ipv6_cidr_block = "::/0"
-  egress_only_gateway_id      = aws_egress_only_internet_gateway.egress[count.index].id
+  egress_only_gateway_id      = aws_egress_only_internet_gateway.egress.id
 }
 
 resource "aws_egress_only_internet_gateway" "egress" {
-  count  = var.enable_egress_only_internet_gateway ? 2 : 0
+  count  = var.enable_egress_only_internet_gateway ? 1 : 0
   vpc_id = aws_vpc.vpc.id
 
   tags = {

--- a/eks/private_subnet.tf
+++ b/eks/private_subnet.tf
@@ -48,7 +48,7 @@ resource "aws_route" "ipv6" {
 
   route_table_id              = aws_route_table.private[count.index].id
   destination_ipv6_cidr_block = "::/0"
-  egress_only_gateway_id      = aws_egress_only_internet_gateway.egress.id
+  egress_only_gateway_id      = aws_egress_only_internet_gateway.egress[0].id
 }
 
 resource "aws_egress_only_internet_gateway" "egress" {

--- a/eks/private_subnet.tf
+++ b/eks/private_subnet.tf
@@ -27,25 +27,36 @@ resource "aws_nat_gateway" "gw" {
 }
 
 resource "aws_route_table" "private" {
-  count = var.enable_nat ? 2 : 0
+  count  = 2
   vpc_id = aws_vpc.vpc.id
-
-  route {
-    cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.gw[count.index].id
-  }
 
   tags = {
     Name = "k8s-private-${count.index}"
   }
 }
 
-resource "aws_egress_only_internet_gateway" "egress_ipv6" {
+resource "aws_route" "nat" {
+  count = var.enable_nat ? 2 : 0
+
+  route_table_id         = aws_route_table.private
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.gw[count.index].id
+}
+
+resource "aws_route" "ipv6" {
   count = var.enable_egress_only_internet_gateway ? 2 : 0
+
+  route_table_id              = aws_route_table.private
+  destination_ipv6_cidr_block = "::/0"
+  egress_only_gateway_id      = aws_egress_only_internet_gateway.egress[count.index].id
+}
+
+resource "aws_egress_only_internet_gateway" "egress" {
+  count  = var.enable_egress_only_internet_gateway ? 2 : 0
   vpc_id = aws_vpc.vpc.id
 
   tags = {
-    Name = "main"
+    Name = "k8s-egress-${count.index}"
   }
 }
 

--- a/eks/private_subnet.tf
+++ b/eks/private_subnet.tf
@@ -38,7 +38,7 @@ resource "aws_route_table" "private" {
 resource "aws_route" "nat" {
   count = var.enable_nat ? 2 : 0
 
-  route_table_id         = aws_route_table.private
+  route_table_id         = aws_route_table.private[count.index].id
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.gw[count.index].id
 }
@@ -46,7 +46,7 @@ resource "aws_route" "nat" {
 resource "aws_route" "ipv6" {
   count = var.enable_egress_only_internet_gateway ? 2 : 0
 
-  route_table_id              = aws_route_table.private
+  route_table_id              = aws_route_table.private[count.index].id
   destination_ipv6_cidr_block = "::/0"
   egress_only_gateway_id      = aws_egress_only_internet_gateway.egress[count.index].id
 }

--- a/eks/private_subnet.tf
+++ b/eks/private_subnet.tf
@@ -15,7 +15,7 @@ resource "aws_subnet" "private" {
 }
 
 resource "aws_eip" "eips" {
-  count = length(var.eips) == 0 ? 2 : 0
+  count = var.enable_nat && length(var.eips) == 0 ? 2 : 0
 }
 
 

--- a/eks/private_subnet.tf
+++ b/eks/private_subnet.tf
@@ -20,14 +20,14 @@ resource "aws_eip" "eips" {
 
 
 resource "aws_nat_gateway" "gw" {
-  count = 2
+  count = var.nat_enabled ? 2 : 0
 
   allocation_id = length(var.eips) == 0 ? aws_eip.eips[count.index].id : var.eips[count.index].id
   subnet_id     = aws_subnet.public[count.index].id
 }
 
 resource "aws_route_table" "private" {
-  count  = 2
+  count = var.nat_enabled ? 2 : 0
   vpc_id = aws_vpc.vpc.id
 
   route {
@@ -37,6 +37,15 @@ resource "aws_route_table" "private" {
 
   tags = {
     Name = "k8s-private-${count.index}"
+  }
+}
+
+resource "aws_egress_only_internet_gateway" "egress_ipv6" {
+  count = var.enable_egress_only_internet_gateway ? 2 : 0
+  vpc_id = aws_vpc.vpc.id
+
+  tags = {
+    Name = "main"
   }
 }
 

--- a/eks/vpc.tf
+++ b/eks/vpc.tf
@@ -2,6 +2,8 @@ resource "aws_vpc" "vpc" {
   cidr_block = var.cidr_block
 
   enable_dns_hostnames = true
+  assign_generated_ipv6_cidr_block = var.enable_ipv6
+
 
   tags = {
     "Name"                                          = var.environment_name

--- a/eks/vpc.tf
+++ b/eks/vpc.tf
@@ -1,7 +1,7 @@
 resource "aws_vpc" "vpc" {
   cidr_block = var.cidr_block
 
-  enable_dns_hostnames = true
+  enable_dns_hostnames             = true
   assign_generated_ipv6_cidr_block = var.enable_ipv6
 
 


### PR DESCRIPTION
Reduce the cost of not running a NAT.
Limits are you can only access IPv6 Endpoints.